### PR TITLE
Fix SFML linker errors in Release build

### DIFF
--- a/SpaDomacaZadaca02/SpaDomacaZadaca02.vcxproj
+++ b/SpaDomacaZadaca02/SpaDomacaZadaca02.vcxproj
@@ -115,7 +115,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>..\SFML-2.5.1\lib</AdditionalLibraryDirectories>
-      <AdditionalDependencies>opengl32.lib; freetype.lib; winmm.lib; sfml-graphics-s-d.lib; sfml-window-s-d.lib; sfml-system-s-d.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib; freetype.lib; winmm.lib; sfml-graphics-s.lib; sfml-window-s.lib; sfml-system-s.lib; kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix Release build not compiling in Visual Studio due to incorrect linking of debug libraries. Should work out of the box, but I do recommend a test run just in case.